### PR TITLE
fix: title not updating when not focused

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ export const App = () => {
 
   return (
     <HelmetProvider>
-      <Helmet>
+      <Helmet defer={false}>
         <title>{time}</title>
         <link rel='icon' type='image/svg+xml' href={clockHours(dayjs.hour())} />
       </Helmet>


### PR DESCRIPTION
## Reason

```ts
    {/* (optional) set to false to not use requestAnimationFrame and instead update the DOM as soon as possible.
        Useful if you want to update the title when the tab is out of focus 
    */}
    defer={false}
```

[defer](https://github.com/nfl/react-helmet) is required to update title when tab is out of focus.

https://github.com/nfl/react-helmet/issues/315

## Solution

set `defer` to false
